### PR TITLE
Move Brandeis Approved Clubs Route

### DIFF
--- a/pages/api/getinfo/brandeisclubs/approved/index.js
+++ b/pages/api/getinfo/brandeisclubs/approved/index.js
@@ -1,0 +1,24 @@
+import dbConnect from "../../../../../utils/dbConnect";
+import Organization from "../../../../../models/Organization";
+
+dbConnect();
+
+export default function (req, res) {
+    return new Promise(resolve => {
+            if (req.method === 'GET') {
+                Organization.find({ active: true }, (err, approvedOrganizations) => {
+                    if (err) {
+                        res.send({ success: false, error: err });
+                        resolve();
+                    } else {
+                        res.send({ success: true, approvedOrganizations: approvedOrganizations });
+                        resolve();
+                    }
+                });
+            } else {
+                res.status(405).send(`HTTP method must be GET on ${req.url}`);
+                resolve();
+            }
+        }
+    )
+}


### PR DESCRIPTION
# Move Brandeis Approved Clubs Route

[Move Brandeis Approved Clubs Route](https://trello.com/c/kPuNo2de)

## Changes Made

Route changed from  `/brandeisclubs/Approved` to `/getinfo/brandeisclubs/approved`. 

## Reason for changes

The lowered `a` is for consistency with other routes in `/getinfo`.

- [ ] New feature
- [ ] Bug fix
- [ ] Library upgrade(s)
