### PR TITLE
Migrate /branvan/get/shuttleRouteSchedule/:name Route

### DIFF
--- a/models/ShuttleRouteSchedule.js
+++ b/models/ShuttleRouteSchedule.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+const Schema = mongoose.Schema;
+
+const ShuttleRouteScheduleSchema = new Schema({
+    name: String,
+    data: Object
+});
+
+module.exports = mongoose.models.ShuttleRouteSchedule || mongoose.model('ShuttleRouteSchedule', ShuttleRouteScheduleSchema);

--- a/pages/api/branvan/get/shuttleRouteSchedule/[name].js
+++ b/pages/api/branvan/get/shuttleRouteSchedule/[name].js
@@ -1,0 +1,27 @@
+import dbConnect from '../../../../../utils/dbConnect.mjs';
+import ShuttleRouteSchedule from '../../../../../models/ShuttleRouteSchedule';
+
+dbConnect();
+
+export default (req, res) => {
+    return new Promise(resolve => {
+        if (req.method === 'GET') {
+            const name = req.query.name;
+            ShuttleRouteSchedule.find({ name }, (err, doc) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else if (!doc) {
+                    res.status(404).send(`Could not find a schedule for route with name ${name}`);
+                    resolve();
+                } else {
+                    res.send(doc);
+                    resolve();
+                }
+            });
+        } else {
+            res.status(405).send(`HTTP method must be GET on ${req.url}`);
+            resolve();
+        }
+    });
+}

--- a/pages/api/branvan/get/shuttleRouteSchedule/index.js
+++ b/pages/api/branvan/get/shuttleRouteSchedule/index.js
@@ -1,0 +1,17 @@
+import dbConnect from '../../../../../utils/dbConnect.mjs';
+
+dbConnect();
+
+export default (req, res) => {
+    return new Promise(resolve => {
+        if (req.method === 'GET') {
+            if (!req.query.name) {
+                res.status(400).send('A name must be provided');
+                resolve();
+            }
+        } else {
+            res.status(405).send(`HTTP method must be GET on ${req.url}`);
+            resolve();
+        }
+    });
+}


### PR DESCRIPTION
# Migrate /branvan/get/shuttleRouteSchedule/:name Route

Adds the `/branvan/get/shuttleRouteSchedule/:name` route, and an appropriate `index.js`.

[Migrate /branvan/get/shuttleRouteSchedule/:name Route](https://trello.com/c/JW286JY4/63-migrate-branvan-get-shuttlerouteschedule-name-route)

## Changes Made

Added 3 files:

* `./pages/api/branvan/get/shuttleRouteSchedule/[name].js` - main route, migrated from legacy backend
* `./pages/api/branvan/get/shuttleRouteSchedule/index.js` - since, if no name is provided, `Next.js` would error and not send an appropriate response with our status code `400`, I had to make an index file that will just respond with a status code `400` with a message (or `405` if not using `GET` request)
* `./models/ShuttleRouteSchedule.js` - new model from legacy backend

## Reason for changes

- [ ] New feature
- [x] Bug fix
- [ ] Library upgrade(s)
