### PR TITLE
Make All Routes Use Promises

### DIFF
--- a/pages/api/announcements/[date].js
+++ b/pages/api/announcements/[date].js
@@ -1,16 +1,26 @@
 import dbConnect from '../../../utils/dbConnect';
-let Announcement = require('../../../models/Announcement');
+const Announcement = require('../../../models/Announcement');
 
 dbConnect();
 
 export default (req, res) => {
-    const { query: { date } } = req;
-    Announcement.find({ startTime: { $lte: date },
-        endTime: { $gte: date } },
-        (err, docs) => {
-        if (err) {
-            console.log("Error finding announcements", err);
-            res.status(500).send("Oop");
-        } else res.send(docs);
+    return new Promise(resolve => {
+        if (req.method === 'GET') {
+            const { query: { date } } = req;
+            Announcement.find({ startTime: { $lte: date },
+                endTime: { $gte: date } },
+                (err, docs) => {
+                if (err) {
+                    res.status(500).send("Oop");
+                    resolve();
+                } else {
+                    res.send(docs);
+                    resolve();
+                }
+            });
+        } else {
+            res.status(405).send(`HTTP method must be GET on ${req.url}`);
+            resolve();
+        }
     });
 }

--- a/pages/api/announcements/index.js
+++ b/pages/api/announcements/index.js
@@ -6,17 +6,27 @@ dbConnect();
 
 //POST method
 export default (req, res) => {
-    let temp = new Announcement({
-        _id: new mongoose.Types.ObjectId(),
-        startTime: req.body.startTime,
-        endTime: req.body.endTime,
-        type: req.body.type,
-        content: req.body.content
-    });
-    temp.save((err, doc) => {
-        if (err) {
-            console.log("Error saving new announcement", err);
-            res.status(500).send("Oop");
-        } else res.send(doc);
+    return new Promise(resolve => {
+        if (req.method === 'POST') {
+            const temp = new Announcement({
+                _id: new mongoose.Types.ObjectId(),
+                startTime: req.body.startTime,
+                endTime: req.body.endTime,
+                type: req.body.type,
+                content: req.body.content
+            });
+            temp.save((err, doc) => {
+                if (err) {
+                    res.status(500).send("Oop");
+                    resolve();
+                } else {
+                    res.send(doc);
+                    resolve();
+                }
+            });
+        } else {
+            res.status(405).send(`HTTP method must be POST on ${req.url}`);
+            resolve();
+        }
     });
 }

--- a/pages/api/brandeisclubs/Approved/index.js
+++ b/pages/api/brandeisclubs/Approved/index.js
@@ -4,12 +4,20 @@ import Organization from "../../../../models/Organization";
 dbConnect();
 
 export default function (req, res) {
-  Organization.find({ active: true }, (err, approvedOrganizations) => {
-    if (err) {
-      res.json({ success: false, error: err });
+  return new Promise(resolve => {
+    if (req.method === 'GET') {
+      Organization.find({ active: true }, (err, approvedOrganizations) => {
+        if (err) {
+          res.json({ success: false, error: err });
+          resolve();
+        } else {
+          res.json({ success: true, approvedOrganizations: approvedOrganizations });
+          resolve();
+        }
+      });
     } else {
-      console.log(approvedOrganizations);
-      res.json({ success: true, approvedOrganizations: approvedOrganizations });
+      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      resolve();
     }
   });
 }

--- a/pages/api/brandeisclubs/Approved/index.js
+++ b/pages/api/brandeisclubs/Approved/index.js
@@ -8,7 +8,7 @@ export default function (req, res) {
     if (req.method === 'GET') {
       Organization.find({ active: true }, (err, approvedOrganizations) => {
         if (err) {
-          res.json({ success: false, error: err });
+          res.status(500).json({ success: false, error: err });
           resolve();
         } else {
           res.json({ success: true, approvedOrganizations: approvedOrganizations });

--- a/pages/api/brandeisclubs/index.js
+++ b/pages/api/brandeisclubs/index.js
@@ -4,26 +4,30 @@ import Organization from "../../../models/Organization";
 dbConnect();
 
 export default (req, res) => {
-  return new Promise((resolve, reject) => {
-    Organization.find({}, (err, docs) => {
-      if (err) {
-        res.statusCode = 500;
-        res.end(JSON.stringify(err));
-        resolve();
-      } else {
-        let result = [];
-
-        docs.forEach((doc) => {
-          var name = doc.name;
-          if (name) {
-            result.push({ name: name });
-          }
-        });
-
-        res.statusCode = 200;
-        res.end(JSON.stringify(result));
-        return resolve();
-      }
-    });
+  return new Promise(resolve => {
+    if (req.method === 'GET') {
+      Organization.find({}, (err, docs) => {
+        if (err) {
+          res.statusCode = 500;
+          res.end(JSON.stringify(err));
+          resolve();
+        } else {
+          let result = [];
+  
+          docs.forEach((doc) => {
+            var name = doc.name;
+            if (name) {
+              result.push({ name });
+            }
+          });
+  
+          res.end(JSON.stringify(result));
+          resolve();
+        }
+      });
+    } else {
+      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      resolve();
+    }
   });
 };

--- a/pages/api/getinfo/getSchedules/index.js
+++ b/pages/api/getinfo/getSchedules/index.js
@@ -4,11 +4,20 @@ import PlaceSchedule from "../../../../models/PlaceSchedule";
 dbConnect();
 
 export default (req, res) => {
-    PlaceSchedule.find({ active: 1 }).exec(function(err, doc) {
-        if (err) {
-            console.log(err);
+    return new Promise(resolve => {
+        if (req.method === 'GET') {
+            PlaceSchedule.find({ active: 1 }).exec(function(err, doc) {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else {
+                    res.send(doc);
+                    resolve();
+                }
+            });
         } else {
-            res.send(doc);
+            res.status(405).send(`HTTP method must be GET on ${req.url}`);
+            resolve();
         }
     });
 };

--- a/pages/api/places/add/index.js
+++ b/pages/api/places/add/index.js
@@ -4,11 +4,13 @@ import Place from "../../../../models/Place";
 dbConnect();
 
 export default function (req, res) {
-  return new Promise((resolve, _reject) => {
+  return new Promise(resolve => {
     if (req.method === "POST") {
       Place.findOne({ Name: req.body.name }, (err, doc) => {
-        console.log(!doc)
-        if (!doc) {
+        if (err) {
+          res.status(500).send({ err });
+          resolve();
+        } else if (!doc) {
           // the place should not have been found
           const newPlace = new Place({
             Name: req.body.name,
@@ -16,19 +18,21 @@ export default function (req, res) {
           });
           newPlace.save((err) => {
             if (err) {
-              console.err(err);
+              res.status(500).send({ err });
+              resolve();
             } else {
               res.send(newPlace);
+              resolve();
             }
           });
         } else {
           res.status(409).send(`${req.body.name} already exists`);
-          return resolve();
+          resolve();
         }
       });
     } else {
-      res.status(405);
-      return resolve();
+      res.status(405).send(`HTTP method must be POST on ${req.url}`);
+      resolve();
     }
   });
 }

--- a/pages/api/places/delete/index.js
+++ b/pages/api/places/delete/index.js
@@ -13,7 +13,7 @@ export default function (req, res) {
             resolve();
           } else {
             res.send(doc);
-            return resolve();
+            resolve();
           }
         }
       );

--- a/pages/api/places/delete/index.js
+++ b/pages/api/places/delete/index.js
@@ -4,12 +4,13 @@ import Place from "../../../../models/Place";
 dbConnect();
 
 export default function (req, res) {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     if (req.method === "PATCH") {
       Place.findOneAndUpdate({ _id: req.body.id }, { active: 0 }).exec(
         (err, doc) => {
           if (err) {
-            return reject(err);
+            res.status(500).send({ err });
+            resolve();
           } else {
             res.send(doc);
             return resolve();
@@ -17,7 +18,8 @@ export default function (req, res) {
         }
       );
     } else {
-      return reject("Invalid HTTP request")
+      res.status(405).send(`HTTP method must be PATCH on ${req.url}`);
+      resolve();
     }
   });
 }

--- a/pages/api/schedules/[week]/[id].js
+++ b/pages/api/schedules/[week]/[id].js
@@ -4,43 +4,50 @@ let PlaceSchedule = require("../../../../models/PlaceSchedule");
 dbConnect();
 
 export default (req, res) => {
-  const {
-    query: { week, id },
-  } = req;
-  if (req.method === "PATCH") {
-    const weekInfo = {
-      sunday: req.body.sunday,
-      saturday: req.body.saturday,
-      friday: req.body.friday,
-      thursday: req.body.thursday,
-      wednesday: req.body.wednesday,
-      tuesday: req.body.tuesday,
-      monday: req.body.monday,
-      week: parseInt(week),
-    };
-    PlaceSchedule.updateOne(
-      { emp_id: id },
-      { $set: { [`weeks.${week}`]: weekInfo } },
-      (err, result) => {
-        if (err) {
-          console.log("Error updating week", err);
-          res.status(500).send("Oop");
-        } else {
-          res.send(result);
+  return new Promise(resolve => {
+    const {
+      query: { week, id },
+    } = req;
+    if (req.method === 'PATCH') {
+      const weekInfo = {
+        sunday: req.body.sunday,
+        saturday: req.body.saturday,
+        friday: req.body.friday,
+        thursday: req.body.thursday,
+        wednesday: req.body.wednesday,
+        tuesday: req.body.tuesday,
+        monday: req.body.monday,
+        week: parseInt(week),
+      };
+      PlaceSchedule.updateOne(
+        { emp_id: id },
+        { $set: { [`weeks.${week}`]: weekInfo } },
+        (err, result) => {
+          if (err) {
+            res.status(500).send({ err });
+            resolve();
+          } else {
+            res.send(result);
+            resolve();
+          }
         }
-      }
-    );
-  } else {
-    PlaceSchedule.findOne({ emp_id: id }, (err, doc) => {
-      if (err) {
-        console.log("Error finding schedule", err);
-        res.status(500).send("Oop");
-      } else if (!doc) {
-        console.log("Could not find schedule");
-        res.status(404).send("Oop");
-      } else {
-        res.send(doc.weeks > week ? doc.weeks[week] : null);
-      }
-    });
-  }
+      );
+    } else if (req.method === 'GET') {
+      PlaceSchedule.findOne({ emp_id: id }, (err, doc) => {
+        if (err) {
+          res.status(500).send({ err });
+          resolve();
+        } else if (!doc) {
+          res.status(404).send("Could not find schedule");
+          resolve();
+        } else {
+          res.send(doc.weeks > week ? doc.weeks[week] : null);
+          resolve();
+        }
+      });
+    } else {
+      res.status(405).send(`HTTP method must be GET or PATCH on ${req.url}`);
+      resolve();
+    }
+  });
 };

--- a/pages/api/schedules/[week]/index.js
+++ b/pages/api/schedules/[week]/index.js
@@ -4,31 +4,38 @@ let PlaceSchedule = require('../../../../models/PlaceSchedule');
 dbConnect();
 
 export default (req, res) => {
-    PlaceSchedule.find({ active: 1 }, (err, docs) => {
-        if (err) {
-            console.log("Error finding schedules", err);
-            res.status(500).send("Oop");
-        } else {
-            const { query: { week } } = req;
-            let schedules = [];
-            console.log("week: " + week);
-            docs.forEach(place => {
-                if (place.weeks.length > week) {
-                    let weekInfo = place.weeks[week];
-                    schedules.push({
-                        name: place.Name,
-                        sunday: weekInfo.sunday,
-                        saturday: weekInfo.saturday,
-                        friday: weekInfo.friday,
-                        thursday: weekInfo.thursday,
-                        wednesday: weekInfo.wednesday,
-                        tuesday: weekInfo.tuesday,
-                        monday: weekInfo.monday,
-                        emp_id: place.emp_id
+    return new Promise(resolve => {
+        if (req.method === 'GET') {
+            PlaceSchedule.find({ active: 1 }, (err, docs) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else {
+                    const { query: { week } } = req;
+                    let schedules = [];
+                    docs.forEach(place => {
+                        if (place.weeks.length > week) {
+                            let weekInfo = place.weeks[week];
+                            schedules.push({
+                                name: place.Name,
+                                sunday: weekInfo.sunday,
+                                saturday: weekInfo.saturday,
+                                friday: weekInfo.friday,
+                                thursday: weekInfo.thursday,
+                                wednesday: weekInfo.wednesday,
+                                tuesday: weekInfo.tuesday,
+                                monday: weekInfo.monday,
+                                emp_id: place.emp_id
+                            });
+                        }
                     });
+                    res.send(schedules);
+                    resolve();
                 }
             });
-            res.send(schedules);
+        } else {
+            res.status(405).send(`HTTP method must be GET on ${req.url}`);
+            resolve();
         }
     });
 }

--- a/pages/api/schedules/delete/index.js
+++ b/pages/api/schedules/delete/index.js
@@ -4,21 +4,23 @@ import PlaceSchedule from "../../../../models/PlaceSchedule";
 dbConnect();
 
 export default function (req, res) {
-  return new Promise((resolve, reject) => {
-    if (req.method === "PATCH") {
+  return new Promise(resolve => {
+    if (req.method === 'PATCH') {
       PlaceSchedule.findOneAndUpdate(
         { emp_id: req.body.emp_id },
         { active: 0 }
       ).exec((err, doc) => {
         if (err) {
-          return reject(err);
+          res.status(500).send({ err });
+          resolve();
         } else {
           res.send(doc);
-          return resolve();
+          resolve();
         }
       });
     } else {
-      return reject("Invalid HTTP request");
+      res.status(405).send(`HTTP method must be PATCH on ${req.url}`);
+      resolve();
     }
   });
 }

--- a/pages/api/schedules/index.js
+++ b/pages/api/schedules/index.js
@@ -4,38 +4,47 @@ let PlaceSchedule = require('../../../models/PlaceSchedule');
 dbConnect();
 
 export default (req, res) => {
-    if (req.method === 'POST') {
-        let temp = new PlaceSchedule({
-            emp_id: req.body.emp_id,
-            Name: req.body.name,
-            group: req.body.group,
-            active: (req.body.active ? req.body.active : 1),
-            weeks: (req.body.weeks ? req.body.weeks : []),
-            monday: req.body.monday,
-            tuesday: req.body.tuesday,
-            wednesday: req.body.wednesday,
-            thursday: req.body.thursday,
-            friday: req.body.friday,
-            saturday: req.body. saturday,
-            sunday: req.body.sunday
-        });
-        temp.save((err, doc) => {
-            if (err) {
-                console.log("Error saving new place");
-                res.status(500).send("Oop");
-            } else res.send(doc);
-        });
-    } else {
-        PlaceSchedule.find({ active: 1 }, (err, docs) => {
-            if (err) {
-                console.log("Error getting places", err);
-                res.status(500).send("Oop");
-            } else {
-                let places = docs.map(place => {
-                    return { name: place.Name, group: place.group };
-                });
-                res.send(places);
-            }
-        });
-    }
+    return new Promise(resolve => {
+        if (req.method === 'POST') {
+            const temp = new PlaceSchedule({
+                emp_id: req.body.emp_id,
+                Name: req.body.name,
+                group: req.body.group,
+                active: (req.body.active ? req.body.active : 1),
+                weeks: (req.body.weeks ? req.body.weeks : []),
+                monday: req.body.monday,
+                tuesday: req.body.tuesday,
+                wednesday: req.body.wednesday,
+                thursday: req.body.thursday,
+                friday: req.body.friday,
+                saturday: req.body. saturday,
+                sunday: req.body.sunday
+            });
+            temp.save((err, doc) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else {
+                    res.send(doc);
+                    resolve();
+                }
+            });
+        } else if (req.method === 'GET') {
+            PlaceSchedule.find({ active: 1 }, (err, docs) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else {
+                    const places = docs.map(place => {
+                        return { name: place.Name, group: place.group };
+                    });
+                    res.send(places);
+                    resolve();
+                }
+            });
+        } else {
+            res.status(405).send(`HTTP method must be POST or GET on ${req.url}`);
+            resolve();
+        }
+    });
 }

--- a/pages/api/sendpushnotification/index.js
+++ b/pages/api/sendpushnotification/index.js
@@ -6,89 +6,96 @@ const axios = require("axios");
 dbConnect();
 
 export default (req, res) => {
-  // here we are checking the lngths of the notifcation body request
-  console.log(req.body.httpLink);
-  let myArrayOfData = [];
+  return new Promise(resolve => {
+    if (req.method === 'POST') {
+    let myArrayOfData = [];
 
-  Organization.findOneAndUpdate(
-    // we then want to go into thee DB and find the organization by name
-    // should find the specific organization by name
+    Organization.findOneAndUpdate(
+      // we then want to go into thee DB and find the organization by name
+      // should find the specific organization by name
 
-    { name: req.body.organization_name },
-    {
-      $addToSet: {
-        // we want to add to the array
-        messagesSent: {
-          title: req.body.title,
-          message: req.body.message,
-          link: req.body.httpLink,
-          deliveredSuccessfully: true,
-        },
-      },
-      $inc: { messageNumber: 1 }, // incerement the number of messages by 1
-    }
-  )
-    .then((organizationModel) => {
-      // then we get the organization back as an object
-      myArrayOfData = organizationModel.members;
-
-      return organizationModel;
-    })
-    .catch((err) => {})
-    .then((organizationModel) => {
-      // here is where we are checking if the organization still is allowed to send notifications
-
-      const maxMessagesAllowed = organizationModel.maxMessagesAllowed;
-      const messageNumber = organizationModel.messageNumber;
-
-      // test that only if max messages is > message sent .. it will send to people
-      // var mainObject = {},
-      if (messageNumber < maxMessagesAllowed) {
-        /// if they can send a notification, then send it
-        let headers = {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        };
-
-        // to get link to open correctly, had to log out and then log in again on expo launched version of app
-
-        let promises = [];
-        myArrayOfData.forEach(function (singleElement, index) {
-          //console.log(index);
-          let userNumber = singleElement;
-          let data = {
-            to: userNumber,
-            data: {
-              link: req.body.httpLink,
-            },
+      { name: req.body.organization_name },
+      {
+        $addToSet: {
+          // we want to add to the array
+          messagesSent: {
             title: req.body.title,
-            body: req.body.message,
-          };
-          console.log("Data to be sent: " + JSON.stringify(data));
-
-          promises.push(
-            axios.post("https://exp.host/--/api/v2/push/send", data, {
-              headers: headers,
-            })
-          );
-        });
-
-        Promise.all(promises).then(function (results) {
-          results.forEach(function (response) {
-            //mainObject[response.identifier] = response.value;
-            console.log(response.status);
-            if (response.status !== 200) {
-              // res.status(500).send("Oop - error sending push notification");
-              console.log("error");
-            }
-          });
-          res.status(200).redirect("/"); // sending OK response
-        });
-      } else {
-        // otherwise send a response saying \/
-        res.json({
-          message: "YOU HAVE EXCEEDED THE MAX NUMBER OF MESSAGES ALLOWED ",
-        });
+            message: req.body.message,
+            link: req.body.httpLink,
+            deliveredSuccessfully: true,
+          },
+        },
+        $inc: { messageNumber: 1 }, // incerement the number of messages by 1
       }
-    });
+    )
+      .then((organizationModel) => {
+        // then we get the organization back as an object
+        myArrayOfData = organizationModel.members;
+
+        return organizationModel;
+      })
+      .catch((err) => {})
+      .then((organizationModel) => {
+        // here is where we are checking if the organization still is allowed to send notifications
+
+        const maxMessagesAllowed = organizationModel.maxMessagesAllowed;
+        const messageNumber = organizationModel.messageNumber;
+
+        // test that only if max messages is > message sent .. it will send to people
+        // var mainObject = {},
+        if (messageNumber < maxMessagesAllowed) {
+          /// if they can send a notification, then send it
+          let headers = {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          };
+
+          // to get link to open correctly, had to log out and then log in again on expo launched version of app
+
+          let promises = [];
+          myArrayOfData.forEach(function (singleElement, index) {
+            //console.log(index);
+            let userNumber = singleElement;
+            let data = {
+              to: userNumber,
+              data: {
+                link: req.body.httpLink,
+              },
+              title: req.body.title,
+              body: req.body.message,
+            };
+            console.log("Data to be sent: " + JSON.stringify(data));
+
+            promises.push(
+              axios.post("https://exp.host/--/api/v2/push/send", data, {
+                headers: headers,
+              })
+            );
+          });
+
+          Promise.all(promises).then(function (results) {
+            const errors = [];
+            results.forEach(function (response) {
+              //mainObject[response.identifier] = response.value;
+              if (response.status !== 200) {
+                // res.status(500).send("Oop - error sending push notification");
+                errors.push(response);
+              }
+            });
+            res.status(200).send(errors).redirect("/"); // sending OK response
+            resolve();
+          });
+        } else {
+          // otherwise send a response saying \/
+          res.json({
+            message: "YOU HAVE EXCEEDED THE MAX NUMBER OF MESSAGES ALLOWED ",
+          });
+          resolve();
+        }
+      });
+    } else {
+      res.status(405).send(`HTTP method must be POST on ${req.url}`);
+      resolve();
+    }
+  });
 };

--- a/pages/api/shuttles/[date]/[id].js
+++ b/pages/api/shuttles/[date]/[id].js
@@ -5,57 +5,63 @@ const { DateTime } = require('luxon');
 dbConnect();
 
 export default (req, res) => {
-    const { query: { date, id } } = req;
-    const start = DateTime.fromISO(date).startOf('day').toJSDate();
-    const end = DateTime.fromISO(date).endOf('day').toJSDate();
-    if (req.method === 'DELETE') {
-        ShuttleActivity.updateOne({ date: { $gte: start, $lte: end }, "times.ID": { $eq: id } },
-            { $pull: { times: { ID: id } } },
-            (err, result) => {
-                if (err) {
-                    console.log("Error removing shuttle time");
-                    res.status(500).send("Oop");
-                } else {
-                    res.send(result);
-
-                    //TODO: connect to samsara api
+    return new Promise(resolve => {
+        const { query: { date, id } } = req;
+        const start = DateTime.fromISO(date).startOf('day').toJSDate();
+        const end = DateTime.fromISO(date).endOf('day').toJSDate();
+        if (req.method === 'DELETE') {
+            ShuttleActivity.updateOne({ date: { $gte: start, $lte: end }, "times.ID": { $eq: id } },
+                { $pull: { times: { ID: id } } },
+                (err, result) => {
+                    if (err) {
+                        res.status(500).send({ err });
+                        resolve();
+                    } else {
+                        res.send(result);
+                        resolve();
+                        //TODO: connect to samsara api
+                    }
                 }
-            }
-        );
-    } else if (req.method === 'PATCH') {
-        let info = {};
-        if (req.body.start) info["times.$.start"] = req.body.start;
-        if (req.body.end) info["times.$.end"] = req.body.end;
-        if (req.body.busID) info["times.$.busID"] = req.body.busID;
-        if (req.body.busName) info["times.$.busName"] = req.body.busName;
-        if (req.body.route) info["times.$.route"] = req.body.route;
-        ShuttleActivity.updateOne({ date: { $gte: start, $lte: end }, "times.ID": { $eq: id } },
-            { $set: info },
-            (err, result) => {
-                if (err) {
-                    console.log("Error updating shuttle time");
-                    res.status(500).send("Oop");
-                } else {
-                    res.send(result);
-
-                    //TODO: connect to samsara api
+            );
+        } else if (req.method === 'PATCH') {
+            let info = {};
+            if (req.body.start) info["times.$.start"] = req.body.start;
+            if (req.body.end) info["times.$.end"] = req.body.end;
+            if (req.body.busID) info["times.$.busID"] = req.body.busID;
+            if (req.body.busName) info["times.$.busName"] = req.body.busName;
+            if (req.body.route) info["times.$.route"] = req.body.route;
+            ShuttleActivity.updateOne({ date: { $gte: start, $lte: end }, "times.ID": { $eq: id } },
+                { $set: info },
+                (err, result) => {
+                    if (err) {
+                        res.status(500).send({ err });
+                        resolve();
+                    } else {
+                        res.send(result);
+                        resolve();
+                        //TODO: connect to samsara api
+                    }
                 }
-            }
-        );
-    } else {
-        ShuttleActivity.findOne({ date: { $gte: start, $lte: end }, "times.ID": { $eq: id } },
-            (err, doc) => {
-                if (err) {
-                    console.log("Error finding shuttle time");
-                    res.status(500).send("Oop");
-                } else if (!doc) {
-                    console.log("Could not find shuttle time");
-                    res.status(404).send("Oop");
-                } else {
-                    const route = doc.times.find((element) => { return element.ID === id });
-                    res.send(route);
+            );
+        } else if (req.method === 'GET') {
+            ShuttleActivity.findOne({ date: { $gte: start, $lte: end }, "times.ID": { $eq: id } },
+                (err, doc) => {
+                    if (err) {
+                        res.status(500).send({ err });
+                        resolve();
+                    } else if (!doc) {
+                        res.status(404).send("Could not find shuttle activity");
+                        resolve();
+                    } else {
+                        const route = doc.times.find((element) => { return element.ID === id });
+                        res.send(route);
+                        resolve();
+                    }
                 }
-            }
-        );
-    }
+            );
+        } else {
+            res.status(405).send(`HTTP method must be DELETE, PATCH, or GET on ${req.url}`);
+            resolve();
+        }
+    });
 }

--- a/pages/api/users/[id].js
+++ b/pages/api/users/[id].js
@@ -5,49 +5,57 @@ let User = require('../../../models/User')
 dbConnect()
 
 export default (req, res) => {
-    const { query: { id } } = req
-    if (req.method === 'PATCH') {
-        User.findById(id, (err, doc) => {
-            if (err) {
-                console.log("Error finding user",err)
-                res.status(500).send("Oop")
-            } else if (!doc) {
-                console.log("Could not find user")
-                res.status(404).send("Oop")
-            } else {
-                if (req.body.username) doc.username = req.body.username
-                if (req.body.email) doc.email = req.body.email
-                if (req.body.userType) doc.userType = req.body.userType
-                if (req.body.picture) doc.picture = req.body.picture
-                if (req.body.password) {
-                    const [hash, salt] = hashPassword(req.body.password)
-                    doc.salt = salt
-                    doc.hash = hash
+    return new Promise(resolve => {
+        const { query: { id } } = req
+        if (req.method === 'PATCH') {
+            User.findById(id, (err, doc) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else if (!doc) {
+                    res.status(404).send("Could not find user");
+                    resolve();
+                } else {
+                    if (req.body.username) doc.username = req.body.username
+                    if (req.body.email) doc.email = req.body.email
+                    if (req.body.userType) doc.userType = req.body.userType
+                    if (req.body.picture) doc.picture = req.body.picture
+                    if (req.body.password) {
+                        const [hash, salt] = hashPassword(req.body.password)
+                        doc.salt = salt
+                        doc.hash = hash
+                    }
+                    doc.save()
+                    res.send(doc)
+                    resolve();
                 }
-                doc.save()
-                res.send(doc)
-            }
-        })
-    } else if (req.method === 'DELETE') {
-        User.findByIdAndDelete(id, (err, doc) => {
-            if (err) {
-                console.log("Error deleting user",err)
-                res.status(500).send("Oop")
-            } else {
-                res.send(doc)
-            }
-        })
-    } else {
-        User.findById(id, (err, doc) => {
-            if (err) {
-                console.log("Error finding user",user)
-                res.status(500).send("Oop")
-            } else if (!doc) {
-                console.log("Could not find user")
-                res.status(404).send("Oop")
-            } else {
-                res.send(doc)
-            }
-        })
-    }
+            })
+        } else if (req.method === 'DELETE') {
+            User.findByIdAndDelete(id, (err, doc) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else {
+                    res.send(doc)
+                    resolve();
+                }
+            })
+        } else if (req.method === 'GET') {
+            User.findById(id, (err, doc) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else if (!doc) {
+                    res.status(404).send("Could not find user");
+                    resolve();
+                } else {
+                    res.send(doc);
+                    resolve();
+                }
+            })
+        } else {
+            res.status(405).send(`HTTP method must be PATCH, DELETE, or GET on ${req.url}`);
+            resolve();
+        }
+    });
 }

--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -5,38 +5,47 @@ let User = require('../../../models/User')
 dbConnect()
 
 export default (req, res) => {
-    if (req.method === 'POST') {
-        const [hash, salt] = hashPassword(req.body.password)
-        let temp = new User({
-            username: req.body.username,
-            email: req.body.email,
-            userType: req.body.userType,
-            picture: req.body.picture,
-            salt: salt,
-            hash: hash
-        })
-        temp.save((err, doc) => {
-            if (err) {
-                console.log("Error saving new user",err)
-                res.status(500).send("Oop")
-            } else res.send(doc)
-        })
-    } else {
-        User.find({}, (err, docs) => {
-            if (err) {
-                console.log("Error getting users",err)
-                res.status(500).send("Oop")
-            } else {
-                let users = docs.map(user => {
-                    return { 
-                        _id: user._id,
-                        username: user.username,
-                        email: user.email,
-                        userType: user.userType
-                    }
-                })
-                res.send(users)
-            }
-        })
-    }
+    return new Promise(resolve => {
+        if (req.method === 'POST') {
+            const [hash, salt] = hashPassword(req.body.password)
+            let temp = new User({
+                username: req.body.username,
+                email: req.body.email,
+                userType: req.body.userType,
+                picture: req.body.picture,
+                salt: salt,
+                hash: hash
+            })
+            temp.save((err, doc) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else {
+                    res.send(doc);
+                    resolve();
+                }
+            })
+        } else if (req.method === 'GET') {
+            User.find({}, (err, docs) => {
+                if (err) {
+                    res.status(500).send({ err });
+                    resolve();
+                } else {
+                    let users = docs.map(user => {
+                        return { 
+                            _id: user._id,
+                            username: user.username,
+                            email: user.email,
+                            userType: user.userType
+                        }
+                    })
+                    res.send(users);
+                    resolve();
+                }
+            })
+        } else {
+            res.status(405).send(`HTTP method must be POST or GET on ${req.url}`);
+            resolve();
+        }
+    });
 }


### PR DESCRIPTION
# Make All Routes Use Promises

All API endpoints and related routes now use promises to resolve requests after the response object is sent. This is mostly for consistency within the `Next.js` framework.

[Make All Routes Use Promises](https://trello.com/c/xOtc3hBw/65-make-all-routes-use-promises)

## Changes Made

Changed all API endpoints that previously didn't use promises to use promises, and condition on `req.method` to ensure correct HTTP methods. All routes now also return the `err` object and a `500` status code on an internal error (mostly DB-related errors) and a `404` and appropriate "not found" error message on not-found DB documents. 

## Reason for changes

- [ ] New feature
- [x] Bug fix
- [ ] Library upgrade(s)
