### PR TITLE
Add error handling for fetch() api

### DIFF
--- a/pages/api/getinfo/libraryHours/today/index.js
+++ b/pages/api/getinfo/libraryHours/today/index.js
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import fetch, { FetchError } from "node-fetch";
 
 const LIBRARY_HOURS_TODAY_URL = "https://calendar.library.brandeis.edu/api_hours_today.php?format=json";
 
@@ -28,11 +28,41 @@ export default (req, res) => {
     return new Promise(resolve => {
         if (req.method === 'GET') {
             fetch(LIBRARY_HOURS_TODAY_URL)
-                .then(response => response.json())
+                .then(response => {
+                    if (!response.ok) {
+                        throw response.status;  // throw a plain Number
+                    } else {
+                        return response.json();
+                    }
+                })
                 .then(data => parseAndReduceTodayHours(data.locations))
                 .then(data => {
                     res.send(data);
                     resolve();
+                })
+                .catch(err => {
+                    if (err instanceof FetchError) {
+                        if (err.message.includes('getaddrinfo ENOTFOUND')) {
+                            // error from fetch() because of incorrect domain
+                            res.status(500).send({err, msg: 'Fetching today\'s library hours failed: Incorrect domain.'});
+                            resolve();
+                        } else {
+                            res.status(500).send({err});
+                            resolve();
+                        }
+                    } else if (err instanceof SyntaxError) {
+                        // error from response.json(), non-json text received
+                        res.status(500).send({err, msg: `JSON syntax error. Check response data from ${LIBRARY_HOURS_TODAY_URL}.`});
+                        resolve();
+                    } else if (err instanceof ReferenceError) {
+                        // error from parseAndReduceTodayHours(), json schema changed
+                        res.status(500).send({err, msg: `JSON schema error. Check response data from ${LIBRARY_HOURS_TODAY_URL}.`});
+                        resolve();
+                    } else {
+                        // response.ok == false
+                        res.status(err).send({msg: `Fetching today's library hours failed. Status code: ${err}`});
+                        resolve();
+                    }
                 });
         } else {
             res.status(405).send(`HTTP method must be GET on ${req.url}`);


### PR DESCRIPTION
# [Add error handling for fetch() api]

Fetching resources from external urls can be unsafe. Once external servers are temporarily down for some reasons, request to our backend could fail.

[Add error handling for fetch() api](https://trello.com/c/b0oQJlTB)

## Changes Made

Changes made to all four files:
- Import `FetchError` from `node-fetch`
- Test if `response.ok` is true in the first `.then` of each fetch
  - If not ok, then throw the HTTP status code received, which is a plain Number (I was about to throw some `Error` here but found no other types are allowed here)
  - If ok, then pass `response.json()` or `response.text()` to the next `.then`
- Add `.catch`
  - Catch domain error (should be rare)
  - Catch other `FetchError`s from `fetch()`
  - Catch `SyntaxError` from `response.json()`
  - Catch `ReferenceError` from parsing functions
  - Catch the plain Number (status code) mentioned before
  - Send error code and messages to indicate these problems.

## Reason for changes

- [ ] New feature
- [x] Bug fix
- [ ] Library upgrade(s)

External servers could fail unexpectedly and produce erros in fetching and parsing functions. These changes help protect database (updateDiningHours, can clear db on code `400` or `404`) and provide useful information locating the problem.