### PR TITLE
Fix News Cron Job Script

### DIFF
--- a/pages/api/cron/updateNews/index.js
+++ b/pages/api/cron/updateNews/index.js
@@ -43,14 +43,20 @@ export default (req, res) => {
         .then((out) => {
           const links = out.map((x) => axios.get(x.link));
           links.map((p) => p.catch((e) => e));
+          const workingLinks = [];
           Promise.allSettled(links)
             .then(function (result) {
               result.forEach(function (element, i) {
-                if (element.status === 'rejected') {
-                  out = out.filter((element) => element !== out[i]);
+                if (element.status === 'fulfilled') {
+                  /**
+                   * previous line: out = out.filter((element) => element !== out[i]);
+                   * for element.status === 'rejected'
+                   * didn't account for index shifting, is what caused issues
+                   */
+                  workingLinks.push(out[i]);
                 }
               });
-              return out;
+              return workingLinks;
             })
             .then((out) => {
               const links = out.map((x) => axios.get(x.link));


### PR DESCRIPTION
# Fix News Cron Job Script

Resolved issue in news cron script.

[Fix News Cron Job Script](https://trello.com/c/7DWvDlUN/86-fix-news-cron-job-script)

## Changes Made

Previously, all `axios.get` calls on news links fetched from [brandeis.edu](brandeis.edu) were (and still are) validated through a `Promise.allSettled` call, which then filtered the results as such:

```javascript
result.forEach(function (element, i) {
  if (element.status === 'rejected') {
    out = out.filter((element) => element !== out[i]);
  }
});
```

However, that does not take into account index shifting when filtering. For example, an array of statuses with contents:

```javascript
['rejected', 'rejected', 'rejected', 'fulfilled', 'fulfilled', 'fulfilled', 'fulfilled']
```

Would become

```javascript
['rejected', 'fulfilled', 'fulfilled', 'fulfilled']
```

As 'removing' indices `0`, `1`, and `2` effectively removes indices `0`, `2`, and  `4`. 

Instead, all `fulfilled` Promises are added to an outgoing array, which is returned from this segment of the Promise chain.

## Reason for changes

- [ ] New feature
- [x] Bug fix
- [ ] Library upgrade(s)
