### PR TITLE
Wenxiao/find one fix

### DIFF
--- a/pages/api/branvan/get/shuttleRouteSchedule/[name].js
+++ b/pages/api/branvan/get/shuttleRouteSchedule/[name].js
@@ -6,7 +6,7 @@ export default (req, res) => {
     logger.info({ req });
     if (req.method === 'GET') {
       const name = req.query.name;
-      ShuttleRouteSchedule.find({ name }, (err, doc) => {
+      ShuttleRouteSchedule.findOne({ name }, (err, doc) => {
         if (err) {
           logger.error({ err }, `Error finding shuttle with name ${name}`);
           res.status(500).send({ err });

--- a/pages/api/branvan/get/stops/[route].js
+++ b/pages/api/branvan/get/stops/[route].js
@@ -12,7 +12,7 @@ export default (req, res) => {
         logger.info({ res });
         resolve();
       } else {
-        ShuttleStop.find({ route }, (err, doc) => {
+        ShuttleStop.findOne({ route }, (err, doc) => {
           if (err) {
             logger.error({ err }, `Error finding shuttle for route ${route}`);
             res.status(500).send(err);

--- a/pages/api/branvan/get/stops/index.js
+++ b/pages/api/branvan/get/stops/index.js
@@ -5,13 +5,13 @@ export default (req, res) => {
   return new Promise((resolve) => {
     logger.info({ req });
     if (req.method === 'GET') {
-      ShuttleStop.findOne({}, (err, docs) => {
+      ShuttleStop.find({}, (err, docs) => {
         if (err) {
           logger.error({ err }, 'Error getting stops');
           res.status(500).send(err);
           logger.info({ res });
           resolve();
-        } else if (!docs) {
+        } else if (!docs.length) {
           logger.warn('No shuttles found');
           res.status(404).send('No shuttles found');
           logger.info({ res });

--- a/pages/api/branvan/get/stops/index.js
+++ b/pages/api/branvan/get/stops/index.js
@@ -5,7 +5,7 @@ export default (req, res) => {
   return new Promise((resolve) => {
     logger.info({ req });
     if (req.method === 'GET') {
-      ShuttleStop.find({}, (err, docs) => {
+      ShuttleStop.findOne({}, (err, docs) => {
         if (err) {
           logger.error({ err }, 'Error getting stops');
           res.status(500).send(err);

--- a/pages/api/getinfo/branvan/notifications/index.js
+++ b/pages/api/getinfo/branvan/notifications/index.js
@@ -6,7 +6,7 @@ export default (req, res) => {
   return new Promise(resolve => {
     logger.info({ req });
     if (req.method === 'GET') {
-      BranvanNotif.find(
+      BranvanNotif.findOne(
         { startTime: { $lte: moment().toDate() }, endTime: { $gte: moment().toDate() } },
         (err, docs) => {
           if (err) {

--- a/pages/api/getinfo/branvan/notifications/index.js
+++ b/pages/api/getinfo/branvan/notifications/index.js
@@ -6,7 +6,7 @@ export default (req, res) => {
   return new Promise(resolve => {
     logger.info({ req });
     if (req.method === 'GET') {
-      BranvanNotif.findOne(
+      BranvanNotif.find(
         { startTime: { $lte: moment().toDate() }, endTime: { $gte: moment().toDate() } },
         (err, docs) => {
           if (err) {


### PR DESCRIPTION
# [Make Single-Valued Routes Use findOne Instead of find]

Any route that has some kind of !doc check should use findOne instead of find.

https://trello.com/c/2HWJuBjr

## Changes Made

Change find to findOne in 
pages/api/branvan/get/shuttleRouteSchedule/[name].js, 
pages/api/branvan/get/stops/[route].js,
pages/api/branvan/get/stops/index.js,
pages/api/getinfo/branvan/notifications/index.js.

## Reason for changes

- [ ] New feature
- [x] Bug fix
- [ ] Library upgrade(s)
