### PR TITLE
Unify /getinfo api responses.

### DIFF
--- a/pages/api/getinfo/brandeisclubs/approved/index.js
+++ b/pages/api/getinfo/brandeisclubs/approved/index.js
@@ -8,7 +8,7 @@ export default function (req, res) {
       Organization.find({ active: true }, (err, approvedOrganizations) => {
         if (err) {
           logger.error({ err }, 'Error fetching active organizations');
-          res.send({ success: false, error: err });
+          res.status(500).send({ success: false, error: err });
           resolve();
         } else {
           res.send({ success: true, approvedOrganizations: approvedOrganizations });
@@ -18,7 +18,7 @@ export default function (req, res) {
       });
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/branvan/available/[date]/[minHr].js
+++ b/pages/api/getinfo/branvan/available/[date]/[minHr].js
@@ -13,7 +13,7 @@ export default (req, res) => {
       }).exec((err, slots) => {
         if (err) {
           logger.error({ err }, 'Error finding branvan availability');
-          res.status(500).send({ err });
+          res.status(500).send({ success: false, error: err });
           logger.info({ res });
           resolve();
         } else {
@@ -32,14 +32,14 @@ export default (req, res) => {
             }
           }
           logger.debug({ hrs }, 'hours computed');
-          res.send({ hrs });
+          res.send({ sucess: true, hrs });
           logger.info({ res }, 'Hours availability fetched');
           resolve();
         }
       });
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/branvan/josephs_running/[date].js
+++ b/pages/api/getinfo/branvan/josephs_running/[date].js
@@ -9,17 +9,17 @@ export default (req, res) => {
       const dateString = req.query.date;
       if (!dateString?.match(/\d{4}-\d{2}-\d{2}/)) {
         logger.warn('Valid date format not provided');
-        res.status(400).send({ err: true });
+        res.status(400).send({ success: false, error: 'Valid date format not provided' });
         logger.info({ res });
         resolve();
       } else {
         JosephRunning.findOne({ date: moment(dateString).toDate() }, (err, running) => {
           if (err) {
             logger.error({ err }, 'Error fetching josephs shuttle');
-            res.status(500).send({ err });
+            res.status(500).send({ sucess: false, error: err });
             resolve();
           } else {
-            res.send({ running: !!running });
+            res.send({ success: true, running: !!running });
             logger.info({ res }, `Running status: ${!!running}`);
             resolve();
           }
@@ -27,7 +27,7 @@ export default (req, res) => {
       }
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/branvan/notifications/index.js
+++ b/pages/api/getinfo/branvan/notifications/index.js
@@ -11,15 +11,15 @@ export default (req, res) => {
         (err, docs) => {
           if (err) {
             logger.error({ err }, 'Error fetching notifications');
-            res.status(500).send({ err });
+            res.status(500).send({ success: false, error: err });
             resolve();
           } else if (!docs.length) {
-            res.send({ empty: true });
+            res.status(404).send({ success: false, error: 'No branvan notifications found' });
             logger.info({ res }, 'No branvan notifications found');
             resolve();
           } else {
             res.send({
-              empty: false,
+              success: true,
               notifications: docs.map(doc => {
                 return {
                   type: doc.type,

--- a/pages/api/getinfo/deletePushTokenFromOrganization/index.js
+++ b/pages/api/getinfo/deletePushTokenFromOrganization/index.js
@@ -22,11 +22,11 @@ export default (req, res) => {
         (err, doc) => {
           if (err) {
             logger.error({ err }, 'Error deleting push token');
-            res.status(500).send({ err });
+            res.status(500).send({ success: false, error: err });
             logger.info({ res });
             resolve();
           } else {
-            res.json({ organization: doc });
+            res.json({ success: true, organization: doc });
             logger.info({ res }, 'Deleted push token');
             resolve();
           }
@@ -34,7 +34,7 @@ export default (req, res) => {
       );
     } else {
       logger.warn(`HTTP method must be DELETE on ${req.url}`);
-      res.status(405).send(`HTTP method must be DELETE on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be DELETE on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/getEvents/index.js
+++ b/pages/api/getinfo/getEvents/index.js
@@ -12,7 +12,7 @@ export default (req, res) => {
         CalendarEvent.find({ year: year, month: month }).exec((err, docs) => {
           if (err) {
             logger.error({ err }, 'Error finding calendar event');
-            res.status(500).send({ err: err });
+            res.status(500).send({ success: false, error: err });
             logger.info({ res });
             resolve();
           } else {
@@ -22,20 +22,20 @@ export default (req, res) => {
               arrFinalFormat.push({ day: date, events: objGrouping[date] });
             }
             logger.debug({ arrFinalFormat }, 'Formatted calendar events');
-            res.send(arrFinalFormat);
+            res.send({ success: true, arrFinalFormat });
             logger.info({ res }, 'Fetched calendar events');
             resolve();
           }
         });
       } else {
         logger.warn('No year or month provided');
-        res.status(400).send({ err: 'no year or month' });
+        res.status(400).send({ success: false, error: 'no year or month' });
         logger.info({ res });
         resolve();
       }
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/getSchedules/index.js
+++ b/pages/api/getinfo/getSchedules/index.js
@@ -8,18 +8,18 @@ export default (req, res) => {
       PlaceSchedule.find({ active: 1 }).exec(function (err, doc) {
         if (err) {
           logger.error({ err }, 'Error fetching place schedules');
-          res.status(500).send({ err });
+          res.status(500).send({ success: false, error: err });
           logger.info({ res });
           resolve();
         } else {
-          res.send(doc);
+          res.send({ success: true, doc });
           logger.info({ res }, 'Fetched place schedules');
           resolve();
         }
       });
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/gymTimes/index.js
+++ b/pages/api/getinfo/gymTimes/index.js
@@ -78,7 +78,7 @@ export default (req, res) => {
         })
         .then(data => getInfo(data))
         .then(data => {
-          res.send(data);
+          res.send({ success: true, data });
           logger.info({ res }, 'Fetched gym times');
           resolve();
         })
@@ -87,38 +87,39 @@ export default (req, res) => {
             if (err.message.includes('getaddrinfo ENOTFOUND')) {
               // error from fetch() because of incorrect domain
               logger.error({ err }, 'Fetching gym times failed: Incorrect domain.');
-              res.status(500).send({ err, msg: 'Fetching gym times failed: Incorrect domain.' });
+              res.status(500).send({ success: false, error: err, msg: 'Fetching gym times failed: Incorrect domain.' });
               logger.info({ res });
               resolve();
             } else {
               logger.error({ err }, `Fetching gym times failed. Status code: ${err}`);
-              res.status(err).send({ err, msg: `Fetching gym times failed. Status code: ${err}` });
+              res.status(err)
+                .send({ success: false, error: err, msg: `Fetching gym times failed. Status code: ${err}` });
               logger.info({ res });
               resolve();
             }
           } else if (err instanceof SyntaxError) {
             // error from response.json(), non-json text received
-            logger.error({ err }, `JSON syntax error. Check response data from ${GYM_TIME_URL}.`);
-            res.status(500).send({ err, msg: `JSON syntax error. Check response data from ${GYM_TIME_URL}.` });
+            logger.error({ err }, `JSON syntax error. Check response from ${GYM_TIME_URL}.`);
+            res.status(500).send({ success: false, error: err, msg: `Check response from ${GYM_TIME_URL}.` });
             logger.info({ res });
             resolve();
           } else if (err instanceof ReferenceError || err instanceof TypeError) {
             // error from getInfo(), json schema changed
-            logger.error({ err }, `JSON schema error. Check response data from ${GYM_TIME_URL}.`);
-            res.status(500).send({ err, msg: `JSON schema error. Check response data from ${GYM_TIME_URL}.` });
+            logger.error({ err }, `JSON schema error. Check response from ${GYM_TIME_URL}.`);
+            res.status(500).send({ success: false, error: err, msg: `Check response from ${GYM_TIME_URL}.` });
             logger.info({ res });
             resolve();
           } else {
             // response.ok == false
             logger.error(`Fetching gym times failed. Status code: ${err}`);
-            res.status(err).send({ msg: `Fetching gym times failed. Status code: ${err}` });
+            res.status(err).send({ success: false, error: `Fetching gym times failed. Status code: ${err}` });
             logger.info({ res });
             resolve();
           }
         });
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/kb/getAppKb/index.js
+++ b/pages/api/getinfo/kb/getAppKb/index.js
@@ -8,18 +8,18 @@ export default (req, res) => {
       KB.find().exec((err, knowledge) => {
         if (err) {
           logger.error({ err }, 'Error getting knowledge');
-          res.status(500).send({ err: err });
+          res.status(500).send({ success: false, error: err });
           logger.info({ res });
           resolve();
         } else {
-          res.send({ kb: knowledge });
+          res.send({ success: true, kb: knowledge });
           logger.info({ res }, 'Fetched knowledge');
           resolve();
         }
       });
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/libraryHours/today/index.js
+++ b/pages/api/getinfo/libraryHours/today/index.js
@@ -40,7 +40,7 @@ export default (req, res) => {
         })
         .then(data => parseAndReduceTodayHours(data.locations))
         .then(data => {
-          res.send(data);
+          res.send({ success: true, data });
           logger.info({ res }, 'Fetched today library hours');
           resolve();
         })
@@ -49,33 +49,35 @@ export default (req, res) => {
             if (err.message.includes('getaddrinfo ENOTFOUND')) {
               // error from fetch() because of incorrect domain
               logger.error({ err }, 'Fetching today\'s library hours failed: Incorrect domain.');
-              res.status(500).send({ err, msg: 'Fetching today\'s library hours failed: Incorrect domain.' });
+              res.status(500)
+                .send({ success: false, error: err, msg: 'Fetching today\'s library hours failed: Incorrect domain.' });
               logger.info({ res });
               resolve();
             } else {
               logger.error({ err }, 'Error fetching today library hours');
-              res.status(500).send({ err });
+              res.status(500).send({ success: false, error: err });
               logger.info({ res });
               resolve();
             }
           } else if (err instanceof SyntaxError) {
             // error from response.json(), non-json text received
-            logger.error({ err }, `JSON syntax error. Check response data from ${LIBRARY_HOURS_TODAY_URL}.`);
+            logger.error({ err }, `JSON syntax error. Check response from ${LIBRARY_HOURS_TODAY_URL}.`);
             res.status(500)
-              .send({ err, msg: `JSON syntax error. Check response data from ${LIBRARY_HOURS_TODAY_URL}.` });
+              .send({ success: false, error: err, msg: `Check response from ${LIBRARY_HOURS_TODAY_URL}.` });
             logger.info({ res });
             resolve();
           } else if (err instanceof ReferenceError) {
             // error from parseAndReduceTodayHours(), json schema changed
-            logger.error({ err }, `JSON schema error. Check response data from ${LIBRARY_HOURS_TODAY_URL}.`);
+            logger.error({ err }, `JSON schema error. Check response from ${LIBRARY_HOURS_TODAY_URL}.`);
             res.status(500)
-              .send({ err, msg: `JSON schema error. Check response data from ${LIBRARY_HOURS_TODAY_URL}.` });
+              .send({ success: false, error: err, msg: `Check response from ${LIBRARY_HOURS_TODAY_URL}.` });
             logger.info({ res });
             resolve();
           } else {
             // response.ok == false
             logger.error(`Fetching today's library hours failed. Status code: ${err}`);
-            res.status(err).send({ msg: `Fetching today's library hours failed. Status code: ${err}` });
+            res.status(err)
+              .send({ success: false, error: `Fetching today's library hours failed. Status code: ${err}` });
             logger.info({ res });
             resolve();
           }

--- a/pages/api/getinfo/libraryHours/week/index.js
+++ b/pages/api/getinfo/libraryHours/week/index.js
@@ -58,7 +58,7 @@ export default (req, res) => {
         })
         .then(data => parseAndReduceWeekHours(data.locations))
         .then(data => {
-          res.send(data);
+          res.send({ success: true, data });
           logger.info({ res }, 'Library week hours fetched');
           resolve();
         }).catch(err => {
@@ -66,39 +66,42 @@ export default (req, res) => {
             if (err.message.includes('getaddrinfo ENOTFOUND')) {
               // error from fetch() because of incorrect domain
               logger.error({ err }, 'Fetching weeks\'s library hours failed: Incorrect domain.');
-              res.status(500).send({ err, msg: 'Fetching weeks\'s library hours failed: Incorrect domain.' });
+              res.status(500)
+                .send({ success: false, error: err, msg: 'Fetching week\'s library hours failed: Incorrect domain.' });
               logger.info({ res });
               resolve();
             } else {
               logger.error(`Fetching weeks's library hours failed. Status code: ${err}`);
-              res.status(err).send({ err, msg: `Fetching weeks's library hours failed. Status code: ${err}` });
+              res.status(err)
+                .send({ success: false, error: err, msg: `Fetching week's library hours failed. Status code: ${err}` });
               resolve();
             }
           } else if (err instanceof SyntaxError) {
             // error from response.json(), non-json text received
             logger.error({ err }, `JSON syntax error. Check response data from ${BRANDEIS_LIBRARY_HOURS_WEEK}.`);
             res.status(500)
-              .send({ err, msg: `JSON syntax error. Check response data from ${BRANDEIS_LIBRARY_HOURS_WEEK}.` });
+              .send({ success: false, error: err, msg: `Check response data from ${BRANDEIS_LIBRARY_HOURS_WEEK}.` });
             logger.info({ res });
             resolve();
           } else if (err instanceof ReferenceError) {
             // error from parseAndReduceWeekHours(), json schema changed
             logger.error({ err }, `JSON schema error. Check response data from ${BRANDEIS_LIBRARY_HOURS_WEEK}.`);
             res.status(500)
-              .send({ err, msg: `JSON schema error. Check response data from ${BRANDEIS_LIBRARY_HOURS_WEEK}.` });
+              .send({ success: false, error: err, msg: `Check response data from ${BRANDEIS_LIBRARY_HOURS_WEEK}.` });
             logger.info({ res });
             resolve();
           } else {
             // response.ok == false
             logger.error(`Fetching weeks's library hours failed. Status code: ${err}`);
-            res.status(err).send({ msg: `Fetching weeks's library hours failed. Status code: ${err}` });
+            res.status(err)
+              .send({ success: false, error: `Fetching week's library hours failed. Status code: ${err}` });
             logger.info({ res });
             resolve();
           }
         });
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/news/index.js
+++ b/pages/api/getinfo/news/index.js
@@ -8,18 +8,18 @@ export default (req, res) => {
       News.find().exec((err, articles) => {
         if (err) {
           logger.error({ err }, 'Error fetching news articles');
-          res.status(500).send({ err: err });
+          res.status(500).send({ success: false, error: err });
           logger.info({ res });
           resolve();
         } else {
-          res.send({ articles: articles });
+          res.send({ success: true, articles: articles });
           logger.info({ res }, 'Fetched news articles');
           resolve();
         }
       });
     } else {
       logger.warn(`HTTP method must be GET on ${req.url}`);
-      res.status(405).send(`HTTP method must be GET on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be GET on ${req.url}` });
       logger.info({ res });
       resolve();
     }

--- a/pages/api/getinfo/pushtokens/index.js
+++ b/pages/api/getinfo/pushtokens/index.js
@@ -22,11 +22,11 @@ export default (req, res) => {
         (err, doc) => {
           if (err) {
             logger.error({ err }, 'Error adding push token to organization');
-            res.status(500).send({ err });
+            res.status(500).send({ success: false, error: err });
             logger.info({ res });
             resolve();
           } else {
-            res.json({ organization: doc });
+            res.json({ success: true, organization: doc });
             logger.info({ res }, 'Pushed token to org');
             resolve();
           }
@@ -34,7 +34,7 @@ export default (req, res) => {
       );
     } else {
       logger.warn(`HTTP method must be POST on ${req.url}`);
-      res.status(405).send(`HTTP method must be POST on ${req.url}`);
+      res.status(405).send({ success: false, error: `HTTP method must be POST on ${req.url}` });
       logger.info({ res });
       resolve();
     }


### PR DESCRIPTION
# Unify /getinfo behaviors on failure

Unify behaviors of `/getinfo` APIs behaviors. 

[Unify /getinfo behaviors on failure](https://trello.com/c/zTCdyIfX)

## Changes Made

All the responses now have a boolean "success" field. For failed requests, an "error" field is attached to their responses which contains text or `err` object, depending on how they were implementated. For successful requests, their payloads are still in the response objects with the same keys as before. 

Some proper status codes added, making each failed request get an non-200 status code.

## Reason for changes

The change makes our responses more predictable and usable.

- [ ] New feature
- [x] Bug fix
- [ ] Library upgrade(s)
