### PR TITLE
Move Snackbar to _app.js and Add Meta Information to Context Variable

### DIFF
--- a/components/schedules/desktop/ScheduleEditor.js
+++ b/components/schedules/desktop/ScheduleEditor.js
@@ -1,20 +1,16 @@
 import {
-  Alert,
   Box,
   Button,
   Divider,
   Grid,
-  IconButton,
   List,
   ListItemButton,
   ListItemText,
-  Snackbar,
   Tooltip
 } from '@mui/material';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { weekNum, packageScheduleData } from '../../../utils/dateUtils.mjs';
-import CloseIcon from '@mui/icons-material/Close';
 
 import dayjs from 'dayjs';
 
@@ -27,14 +23,12 @@ import LoadingLogo from '../../shared/LoadingLogo.js';
 
 const schedulesCache = {};
 
-export default function ScheduleEditor () {
+export default function ScheduleEditor ({ snackMeta, setSnackMeta }) {
   const [schedules, setSchedules] = useState(undefined);
   const [placeIndex, setPlaceIndex] = useState(0);
   const [day, setDay] = useState(undefined);
   const [times, setTimes] = useState({});
   const [edit, setEdit] = useState(false);
-
-  const [snackMeta, setSnackMeta] = useState({ open: false, message: undefined, severity: 'success' });
 
   const [deleteModal, setDeleteModal] = useState(false);
   const [addPlaceModal, setAddPlaceModal] = useState(false);
@@ -110,25 +104,6 @@ export default function ScheduleEditor () {
       });
     });
   };
-
-  const closeSnack = () => {
-    const snack = JSON.clone(snackMeta);
-    snack.open = false;
-    setSnackMeta(snack);
-  };
-
-  const snackAction = (
-    <div>
-      <IconButton
-        size="small"
-        aria-label="close"
-        color="inherit"
-        onClick={closeSnack}
-      >
-        <CloseIcon fontSize="small" />
-      </IconButton>
-    </div>
-  );
 
   useEffect(() => {
     fetchWeekSchedule(dayjs());
@@ -219,18 +194,6 @@ export default function ScheduleEditor () {
           deleteAction={() => setDeleteModal(true)}
           addAction={() => setAddPlaceModal(true)}
         />
-        <Snackbar
-          open={snackMeta.open}
-          autoHideDuration={3500}
-          onClose={closeSnack}
-          action={snackAction}
-          key='topright'
-          sx={{ maxWidth: 600 }}
-        >
-          <Alert onClose={closeSnack} severity={snackMeta.severity} sx={{ width: '100%' }}>
-            {snackMeta.message}
-          </Alert>
-        </Snackbar>
         <DeleteConfirmation
           open={deleteModal}
           setOpen={setDeleteModal}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,12 @@
 import '../styles/globals.css';
-import '../styles/materialize.css';
+// import '../styles/materialize.css';
 import '../styles/mui.css';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { ThemeProvider } from 'styled-components';
-import { createTheme } from '@mui/material';
+import { Alert, createTheme, IconButton, Snackbar } from '@mui/material';
 import { access } from '../utils/rolesUtils';
 import { useRouter } from 'next/router';
 import { getSession, Provider, signIn, useSession } from 'next-auth/client';
@@ -28,6 +29,8 @@ const inputTheme = createTheme({ palette: { primary: { main: '#1B4370' } } });
 function TLApp ({ Component, pageProps }) {
   const router = useRouter();
 
+  const [snackMeta, setSnackMeta] = useState({ open: false, message: undefined, severity: 'success' });
+
   useEffect(() => {
     const jssStyles = document.querySelector('#jss-server-side');
     if (jssStyles) {
@@ -41,6 +44,25 @@ function TLApp ({ Component, pageProps }) {
     } else return null;
   }
 
+  const closeSnack = () => {
+    const snack = JSON.clone(snackMeta);
+    snack.open = false;
+    setSnackMeta(snack);
+  };
+
+  const snackAction = (
+    <div>
+      <IconButton
+        size="small"
+        aria-label="close"
+        color="inherit"
+        onClick={closeSnack}
+      >
+        <CloseIcon fontSize="small" />
+      </IconButton>
+    </div>
+  );
+
   return (
     <div style={{ height: '100%' }}>
       <Provider session={pageProps.session}>
@@ -48,7 +70,21 @@ function TLApp ({ Component, pageProps }) {
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <ThemeProvider theme={inputTheme}>
               {nav()}
-              <div className="row"><Component {...pageProps} /></div>
+              <div className="row">
+                <Component {...pageProps} snackMeta={snackMeta} setSnackMeta={setSnackMeta}/>
+                <Snackbar
+                  open={snackMeta.open}
+                  autoHideDuration={3500}
+                  onClose={closeSnack}
+                  action={snackAction}
+                  key='topright'
+                  sx={{ maxWidth: 600 }}
+                >
+                  <Alert onClose={closeSnack} severity={snackMeta.severity} sx={{ width: '100%' }}>
+                    {snackMeta.message}
+                  </Alert>
+                </Snackbar>
+              </div>
             </ThemeProvider>
           </LocalizationProvider>
         </Auth>

--- a/pages/schedules.js
+++ b/pages/schedules.js
@@ -3,7 +3,7 @@ import ScheduleEditor from '../components/schedules/desktop/ScheduleEditor';
 import ScheduleView from '../components/schedules/mobile/ScheduleView';
 import styles from '../styles/Home.module.css';
 
-export default function Schedules ({ isMobile }) {
+export default function Schedules ({ isMobile, snackMeta, setSnackMeta }) {
   return (
     <div className={styles.container}>
       <Head>
@@ -11,7 +11,9 @@ export default function Schedules ({ isMobile }) {
       </Head>
 
       <main className={styles.main}>
-        { isMobile ? <ScheduleView forEditPage/> : <ScheduleEditor />}
+        { isMobile
+          ? <ScheduleView forEditPage />
+          : <ScheduleEditor setSnackMeta={setSnackMeta} snackMeta={snackMeta}/>}
       </main>
 
       <footer className={styles.footer}></footer>


### PR DESCRIPTION
# Move Snackbar to _app.js and Add Meta Information to Context Variable

Moves snackbar logic to parent `_app.js` file to avoid repetitive logic.

[Move Snackbar to _app.js and Add Meta Information to Context Variable](https://trello.com/c/2hGHSD8Q/96-move-snackbar-to-appjs-and-add-meta-information-to-context-variable)

## Changes Made

For future snack-related changes, the `snackMeta` and `setSnackMeta` variables can be passed down through components. Eventually, we can move this to global or context-based variables. This fix should be OK for now.

## Reason for changes

- [x] New feature
- [ ] Bug fix
- [ ] Library upgrade(s)
