### PR TITLE
added offline testing

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+venv/
+.env
+Dockerfile
+.dockerignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:16
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json into the container
+COPY ../package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the app code into the container
+COPY .. .
+
+# Build the app for production
+RUN npm run build
+
+# Set the command to start the app in production mode
+CMD ["npm", "start"]

--- a/docker/Dockerfile.api-test
+++ b/docker/Dockerfile.api-test
@@ -1,0 +1,19 @@
+FROM node:16
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json into the container
+RUN npm init -y
+
+# Install dependencies
+RUN npm install node-fetch chai mongoose
+
+RUN npm i -g mocha
+
+
+# Copy the rest of the app code into the container
+COPY ../tests .
+
+# Set the command to run the API tests
+CMD ["mocha", "--colors", "./utils/apiUtils.spec.mjs", "--timeout", "20000"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - 3000:3000
+    environment:
+      ADMIN_PANEL_DATABASE_URL: "mongodb://db:27017/testing"
+      API_TOKEN_SECRET: "random_api_token_secret"
+      DB_ACCESS_TOKEN_SECRET: "random_access_token_secret"
+
+    command: npm start
+    depends_on:
+      - db
+
+  db:
+    image: mongo:latest
+    ports:
+      - 27017:27017
+
+  api-test:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api-test
+    environment:
+      ADMIN_PANEL_DATABASE_URL: "mongodb://db:27017/testing"
+      API_TOKEN_SECRET: "random_api_token_secret"
+      APP_URL: "http://app:3000/"
+    depends_on:
+      - app
+


### PR DESCRIPTION
# Offline Testing

Added npm run test:api. This will create 3 docker containers  - on running the server, one running a mongodb instance, and the last running the api tests. 

__Note__: You must have docker and docker compose installed for the command to run

## Changes Made

Added new file called docker, and relevent docker compose file and Dockerfiles

## Reason for changes

- [x] New feature
- [ ] Bug fix
- [ ] Library upgrade(s)
